### PR TITLE
Fix conv read

### DIFF
--- a/Realtime/Realtime/Internal/Connection/LCConnection.cs
+++ b/Realtime/Realtime/Internal/Connection/LCConnection.cs
@@ -168,6 +168,7 @@ namespace LeanCloud.Realtime.Internal.Connection {
                     // 应答
                     int requestIndex = command.I;
                     if (requestToResponses.TryGetValue(command, out TaskCompletionSource<GenericCommand> tcs)) {
+                        requestToResponses.Remove(command);
                         if (command.HasErrorMessage) {
                             // 错误
                             ErrorCommand error = command.ErrorMessage;
@@ -179,7 +180,6 @@ namespace LeanCloud.Realtime.Internal.Connection {
                         } else {
                             tcs.TrySetResult(command);
                         }
-                        requestToResponses.Remove(command);
                     } else {
                         LCLogger.Error($"No request for {requestIndex}");
                     }

--- a/Realtime/Realtime/Internal/Controller/LCIMMessageController.cs
+++ b/Realtime/Realtime/Internal/Controller/LCIMMessageController.cs
@@ -186,10 +186,13 @@ namespace LeanCloud.Realtime.Internal.Controller {
             LCIMMessage msg) {
             ReadCommand read = new ReadCommand();
             ReadTuple tuple = new ReadTuple {
-                Cid = convId,
-                Mid = msg.Id,
-                Timestamp = msg.SentTimestamp
+                Cid = convId
             };
+            // 当不传 msg 时，服务端将其收到的最后一条消息标记为已读，可能与客户端不一致
+            if (msg != null) {
+                tuple.Mid = msg.Id;
+                tuple.Timestamp = msg.SentTimestamp;
+            }
             read.Convs.Add(tuple);
             GenericCommand command = NewCommand(CommandType.Read);
             command.ReadMessage = read;

--- a/Realtime/Realtime/Public/Conversation/LCIMConversation.cs
+++ b/Realtime/Realtime/Public/Conversation/LCIMConversation.cs
@@ -185,7 +185,7 @@ namespace LeanCloud.Realtime {
         /// </summary>
         /// <returns></returns>
         public virtual async Task Read() {
-            if (LastMessage == null) {
+            if (Unread == 0) {
                 return;
             }
             await Client.MessageController.Read(Id, LastMessage);


### PR DESCRIPTION
- 修复当 LastMessage 为 null 时，调用 LCIMConversation#Read 的异常。修改方式为省略掉 Message Id，由服务端的最新消息作为参数标记已读。
- 调整 SDK 内部获取对话的实现逻辑。统一为 GetOrQueryConversation，即优先从内存中查找，再从服务端查询。