### PR TITLE
适配内建账户系统 TDSUser

### DIFF
--- a/LiveQuery/LiveQuery/Public/LCLiveQuery.cs
+++ b/LiveQuery/LiveQuery/Public/LCLiveQuery.cs
@@ -209,7 +209,7 @@ namespace LeanCloud.LiveQuery {
                 data.TryGetValue("object", out object obj) &&
                 obj is Dictionary<string, object> dict) {
                 LCObjectData objectData = LCObjectData.Decode(dict);
-                LCUser user = new LCUser(objectData);
+                LCUser user = LCUser.GenerateUser(objectData);
                 liveQuery.OnLogin?.Invoke(user);
             }
         }

--- a/Realtime/Realtime.Test/Message.cs
+++ b/Realtime/Realtime.Test/Message.cs
@@ -164,6 +164,7 @@ namespace Realtime.Test {
 
         [Test]
         [Order(5)]
+        [Timeout(20000)]
         public async Task Unread() {
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
             string clientId = Guid.NewGuid().ToString();

--- a/Storage/Storage/Public/LCUser.cs
+++ b/Storage/Storage/Public/LCUser.cs
@@ -108,10 +108,6 @@ namespace LeanCloud.Storage {
             
         }
 
-        public LCUser(LCObjectData objectData) : this() {
-            Merge(objectData);
-        }
-
         /// <summary>
         /// Signs up a new user.
         /// </summary>
@@ -165,7 +161,7 @@ namespace LeanCloud.Storage {
             };
             Dictionary<string, object> response = await LCCore.HttpClient.Post<Dictionary<string, object>>("usersByMobilePhone", data: data);
             LCObjectData objectData = LCObjectData.Decode(response);
-            currentUser = new LCUser(objectData);
+            currentUser = GenerateUser(objectData);
 
             await SaveToLocal();
 
@@ -429,7 +425,7 @@ namespace LeanCloud.Storage {
             Dictionary<string, object> response = await LCCore.HttpClient.Get<Dictionary<string, object>>("users/me",
                 headers: headers);
             LCObjectData objectData = LCObjectData.Decode(response);
-            currentUser = new LCUser(objectData);
+            currentUser = GenerateUser(objectData);
             return currentUser;
         }
 
@@ -586,7 +582,7 @@ namespace LeanCloud.Storage {
         static async Task<LCUser> Login(Dictionary<string, object> data) {
             Dictionary<string, object> response = await LCCore.HttpClient.Post<Dictionary<string, object>>("login", data: data);
             LCObjectData objectData = LCObjectData.Decode(response);
-            currentUser = new LCUser(objectData);
+            currentUser = GenerateUser(objectData);
 
             await SaveToLocal();
 
@@ -602,7 +598,8 @@ namespace LeanCloud.Storage {
                 { "authData", authData }
             });
             LCObjectData objectData = LCObjectData.Decode(response);
-            currentUser = new LCUser(objectData);
+
+            currentUser = GenerateUser(objectData);
 
             await SaveToLocal();
 
@@ -768,6 +765,12 @@ namespace LeanCloud.Storage {
             currentUser = this;
             await SaveToLocal();
             return this;
+        }
+
+        public static LCUser GenerateUser(LCObjectData objectData) {
+            LCUser user = Create(CLASS_NAME) as LCUser;
+            user.Merge(objectData);
+            return user;
         }
     }
 }

--- a/Storage/Storage/Public/Leaderboard/LCRanking.cs
+++ b/Storage/Storage/Public/Leaderboard/LCRanking.cs
@@ -47,7 +47,7 @@ namespace LeanCloud.Storage {
             }
             if (data.TryGetValue("user", out object user)) {
                 LCObjectData objectData = LCObjectData.Decode(user as System.Collections.IDictionary);
-                ranking.User = new LCUser(objectData);
+                ranking.User = LCUser.GenerateUser(objectData);
             }
             if (data.TryGetValue("statisticName", out object statisticName)) {
                 ranking.StatisticName = statisticName as string;


### PR DESCRIPTION
移除所有 new LCUser() 操作，全部走 LCObject#Create() 接口，方便 TDSUser 继承 LCUser