### PR TITLE
fix: upm link.xml

### DIFF
--- a/Common/Common.AOT/Common.AOT.csproj
+++ b/Common/Common.AOT/Common.AOT.csproj
@@ -48,4 +48,9 @@
       <Link>Common\Exception\LCException.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Common.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/Common/Common.AOT/Resources/link.xml
+++ b/Common/Common.AOT/Resources/link.xml
@@ -1,0 +1,4 @@
+<linker>
+  <assembly fullname="Common" preserve="all"/>
+  <assembly fullname="LC.Newtonsoft.Json" preserve="all"/>
+</linker>

--- a/LiveQuery/LiveQuery.AOT/LiveQuery.AOT.csproj
+++ b/LiveQuery/LiveQuery.AOT/LiveQuery.AOT.csproj
@@ -24,4 +24,9 @@
       <Link>LiveQuery\Public\LCQueryExtension.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>LiveQuery.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/LiveQuery/LiveQuery.AOT/Resources/link.xml
+++ b/LiveQuery/LiveQuery.AOT/Resources/link.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="LiveQuery" preserve="all"/>
+</linker>

--- a/Realtime/Realtime.AOT/Realtime.AOT.csproj
+++ b/Realtime/Realtime.AOT/Realtime.AOT.csproj
@@ -121,4 +121,9 @@
       <Link>Realtime\Internal\Router\LCRTMRouter.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Realtime.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/Realtime/Realtime.AOT/Resources/link.xml
+++ b/Realtime/Realtime.AOT/Resources/link.xml
@@ -1,0 +1,4 @@
+<linker>
+  <assembly fullname="Realtime" preserve="all"/>
+  <assembly fullname="LC.Google.Protobuf" preserve="all"/>
+</linker>

--- a/Storage/Storage.AOT/Resources/link.xml
+++ b/Storage/Storage.AOT/Resources/link.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="Storage" preserve="all"/>
+</linker>

--- a/Storage/Storage.AOT/Storage.AOT.csproj
+++ b/Storage/Storage.AOT/Storage.AOT.csproj
@@ -174,4 +174,9 @@
       <Link>Storage\Public\User\LCUserQueryCondition.cs</Link>
     </Compile>
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Storage.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>

--- a/Storage/Storage.Unity/Resources/link.xml
+++ b/Storage/Storage.Unity/Resources/link.xml
@@ -1,0 +1,3 @@
+<linker>
+  <assembly fullname="Storage.Unity" preserve="all"/>
+</linker>

--- a/Storage/Storage.Unity/Storage.Unity.csproj
+++ b/Storage/Storage.Unity/Storage.Unity.csproj
@@ -19,4 +19,9 @@
     <Folder Include="Public\" />
     <Folder Include="Internal\" />
   </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="Resources\link.xml">
+      <LogicalName>Storage.Unity.xml</LogicalName>
+    </EmbeddedResource>
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
[参考](https://github.com/jilleJr/Newtonsoft.Json-for-Unity/wiki/Embed-link.xml-in-UPM-package)
将 link.xml 打包至 dll，防止 UPM 方式引用不到的情况