### PR TITLE
修复 Push 上传无效记录的 bug

### DIFF
--- a/Push/Push.Unity/Assets/LeanCloud/Push/Android/Common/Plugins/com/leancloud/push/Utils.java
+++ b/Push/Push.Unity/Assets/LeanCloud/Push/Android/Common/Plugins/com/leancloud/push/Utils.java
@@ -59,6 +59,9 @@ public class Utils {
     }
 
     public static void sendDeviceInfo(String vendor, String regId) {
+        if (Utils.isNullOrEmpty(regId)) {
+            return;
+        }
         Map<String, Object> deviceInfo = new HashMap<>();
         deviceInfo.put("deviceType", "android");
         deviceInfo.put("vendor", vendor);

--- a/Push/Push.Unity/Assets/LeanCloud/Push/Android/HuaWei/Plugins/com/leancloud/push/huawei/HuaWeiPushManager.java
+++ b/Push/Push.Unity/Assets/LeanCloud/Push/Android/HuaWei/Plugins/com/leancloud/push/huawei/HuaWeiPushManager.java
@@ -20,6 +20,7 @@ public class HuaWeiPushManager {
                     String appId = AGConnectServicesConfig.fromContext(UnityPlayer.currentActivity).getString("client/app_id");
                     Log.i(Utils.TAG, "app id: " + appId);
                     String regId = HmsInstanceId.getInstance(UnityPlayer.currentActivity).getToken(appId, HmsMessaging.DEFAULT_TOKEN_SCOPE);
+                    Log.i(Utils.TAG, "reg id: " + regId);
                     Utils.sendDeviceInfo("HMS", regId);
 
                     HmsMessaging.getInstance(UnityPlayer.currentActivity).turnOnPush().addOnCompleteListener(new OnCompleteListener<Void>() {


### PR DESCRIPTION
## 原因

华为提供了两个获取 regId 的途径，在 EMUI 10 以下可能返回空，导致上传记录中不包含 regId 的 bug

## 修复方案

在厂商推送上传推送信息时，对 regId 判空，空即丢弃