### PR TITLE
修复七牛云上传 key 不合法的问题

### DIFF
--- a/Storage/Storage/Internal/File/LCQiniuUploader.cs
+++ b/Storage/Storage/Internal/File/LCQiniuUploader.cs
@@ -54,7 +54,9 @@ namespace LeanCloud.Storage.Internal.File {
         }
 
         internal async Task Upload(Action<long, long> onProgress) {
-            string encodedObjectName = Uri.EscapeUriString(Convert.ToBase64String(Encoding.UTF8.GetBytes(key)));
+            string encodedObjectName = Convert.ToBase64String(Encoding.UTF8.GetBytes(key))
+                .Replace("+", "-")
+                .Replace("/", "_");
 
             HttpClient client = new HttpClient();
 


### PR DESCRIPTION
[七牛云要求是安全的 base64 编码的 url](https://developer.qiniu.com/kodo/1231/appendix#urlsafe-base64)