### PR TITLE
重构内置子类请求接口

### DIFF
--- a/Storage/Storage.Test/CloudTest.cs
+++ b/Storage/Storage.Test/CloudTest.cs
@@ -63,7 +63,7 @@ namespace Storage.Test {
         [Test]
         public void CatchLCException() {
             LCException ex = Assert.CatchAsync<LCException>(() => LCCloud.Run("lcexception"));
-            Assert.AreEqual(ex.Code, 123);
+            Assert.AreEqual(ex.Code, 1);
             Assert.AreEqual(ex.Message, "Runtime exception");
         }
 
@@ -72,6 +72,13 @@ namespace Storage.Test {
             LCException ex = Assert.CatchAsync<LCException>(() => LCCloud.Run("exception"));
             Assert.AreEqual(ex.Code, 1);
             Assert.AreEqual(ex.Message, "Hello, exception");
+        }
+
+        [Test]
+        public void CatchEngineException() {
+            LCException ex = Assert.CatchAsync<LCException>(() => LCCloud.Run("engineException"));
+            Assert.AreEqual(ex.Code, 111);
+            Assert.AreEqual(ex.Message, "Engine exception");
         }
 
         [Test]

--- a/Storage/Storage.Test/FriendTest.cs
+++ b/Storage/Storage.Test/FriendTest.cs
@@ -19,7 +19,7 @@ namespace Storage.Test {
 
         async Task<LCFriendshipRequest> GetRequest() {
             LCUser user = await LCUser.GetCurrent();
-            LCQuery<LCFriendshipRequest> query = new LCQuery<LCFriendshipRequest>("_FriendshipRequest")
+            LCQuery<LCFriendshipRequest> query = new LCQuery<LCFriendshipRequest>(LCFriendshipRequest.CLASS_NAME)
                 .WhereEqualTo("friend", user)
                 .WhereEqualTo("status", "pending");
             return await query.First();

--- a/Storage/Storage/Internal/LCStorage.cs
+++ b/Storage/Storage/Internal/LCStorage.cs
@@ -20,12 +20,14 @@ namespace LeanCloud.Storage.Internal {
             });
 
             // 注册 LeanCloud 内部子类化类型
-            LCObject.RegisterSubclass(LCUser.CLASS_NAME, () => new LCUser());
-            LCObject.RegisterSubclass(LCRole.CLASS_NAME, () => new LCRole());
-            LCObject.RegisterSubclass(LCFile.CLASS_NAME, () => new LCFile());
-            LCObject.RegisterSubclass(LCStatus.CLASS_NAME, () => new LCStatus());
-            LCObject.RegisterSubclass(LCFriendshipRequest.CLASS_NAME, () => new LCFriendshipRequest());
-            LCObject.RegisterSubclass(LCInstallation.CLASS_NAME, () => new LCInstallation());
+            LCObject.RegisterSubclass(LCUser.CLASS_NAME, () => new LCUser(), LCUser.ENDPOINT);
+            LCObject.RegisterSubclass(LCRole.CLASS_NAME, () => new LCRole(), LCRole.ENDPOINT);
+            LCObject.RegisterSubclass(LCFile.CLASS_NAME, () => new LCFile(), LCFile.ENDPOINT);
+            LCObject.RegisterSubclass(LCStatus.CLASS_NAME, () => new LCStatus(), LCStatus.ENDPOINT);
+            LCObject.RegisterSubclass(LCFriendshipRequest.CLASS_NAME, () => new LCFriendshipRequest(), LCFriendshipRequest.ENDPOINT);
+            LCObject.RegisterSubclass(LCInstallation.CLASS_NAME, () => new LCInstallation(), LCInstallation.ENDPOINT);
+            LCObject.RegisterSubclass("_Follower", () => new LCObject("_Follower"), "followers");
+            LCObject.RegisterSubclass("_Followee", () => new LCObject("_Followee"), "followees");
         }
     }
 }

--- a/Storage/Storage/Internal/Object/LCSubClassInfo.cs
+++ b/Storage/Storage/Internal/Object/LCSubClassInfo.cs
@@ -6,18 +6,18 @@ namespace LeanCloud.Storage.Internal.Object {
             get;
         }
 
-        internal Type Type {
-            get;
-        }
-
         internal Func<LCObject> Constructor {
             get;
         }
 
-        internal LCSubclassInfo(string className, Type type, Func<LCObject> constructor) {
+        internal string Endpoint {
+            get;
+        }
+
+        internal LCSubclassInfo(string className, Func<LCObject> constructor, string endpoint = null) {
             ClassName = className;
-            Type = type;
             Constructor = constructor;
+            Endpoint = endpoint;
         }
     }
 }

--- a/Storage/Storage/Public/Friendship/LCFriendshipRequest.cs
+++ b/Storage/Storage/Public/Friendship/LCFriendshipRequest.cs
@@ -5,6 +5,7 @@
     /// </summary>
     public class LCFriendshipRequest : LCObject {
         public const string CLASS_NAME = "_FriendshipRequest";
+        public const string ENDPOINT = "friendshiprequests";
 
         public const int STATUS_PENDING = 0x01;
         public const int STATUS_ACCEPTED = 0x02;

--- a/Storage/Storage/Public/LCFile.cs
+++ b/Storage/Storage/Public/LCFile.cs
@@ -14,6 +14,7 @@ namespace LeanCloud.Storage {
     /// </summary>
     public class LCFile : LCObject {
         public const string CLASS_NAME = "_File";
+        public const string ENDPOINT = "files";
 
         private const string METADATA_SIZE_KEY = "size";
         private const string METADATA_SUM_KEY = "_checksum";
@@ -197,7 +198,7 @@ namespace LeanCloud.Storage {
             if (string.IsNullOrEmpty(ObjectId)) {
                 return;
             }
-            string path = $"files/{ObjectId}";
+            string path = $"{GetClassEndpoint(ClassName)}/{ObjectId}";
             await LCCore.HttpClient.Delete(path);
         }
 

--- a/Storage/Storage/Public/LCInstallation.cs
+++ b/Storage/Storage/Public/LCInstallation.cs
@@ -5,6 +5,7 @@ using LeanCloud.Common;
 namespace LeanCloud.Storage {
     public class LCInstallation : LCObject {
         public const string CLASS_NAME = "_Installation";
+        public const string ENDPOINT = "installations";
 
         private const string DEVICE_DATA = ".devicedata";
 

--- a/Storage/Storage/Public/LCQuery.cs
+++ b/Storage/Storage/Public/LCQuery.cs
@@ -22,7 +22,9 @@ namespace LeanCloud.Storage {
 
         private string endpoint;
 
-        public string Endpoint => string.IsNullOrEmpty(endpoint) ? $"classes/{ClassName}" : endpoint;
+        public string Endpoint => !string.IsNullOrEmpty(endpoint) ?
+            endpoint :
+            LCObject.GetClassEndpoint(ClassName);
 
         public LCCompositionalCondition Condition {
             get; internal set;
@@ -421,7 +423,7 @@ namespace LeanCloud.Storage {
             if (string.IsNullOrEmpty(objectId)) {
                 throw new ArgumentNullException(nameof(objectId));
             }
-            string path = $"classes/{ClassName}/{objectId}";
+            string path = $"{LCObject.GetClassEndpoint(ClassName)}/{objectId}";
             Dictionary<string, object> queryParams = null;
             string includes = Condition.BuildIncludes();
             if (!string.IsNullOrEmpty(includes)) {

--- a/Storage/Storage/Public/LCRole.cs
+++ b/Storage/Storage/Public/LCRole.cs
@@ -4,6 +4,7 @@
     /// </summary>
     public class LCRole : LCObject {
         public const string CLASS_NAME = "_Role";
+        public const string ENDPOINT = "roles";
 
         /// <summary>
         /// The name of a LCRole.

--- a/Storage/Storage/Public/Status/LCStatus.cs
+++ b/Storage/Storage/Public/Status/LCStatus.cs
@@ -12,6 +12,7 @@ namespace LeanCloud.Storage {
     /// </summary>
     public class LCStatus : LCObject {
         public const string CLASS_NAME = "_Status";
+        public const string ENDPOINT = "statuses";
 
         /// Public, shown on followees' timeline.
         public const string InboxTypeDefault = "default";

--- a/Storage/Storage/Public/User/LCUser.cs
+++ b/Storage/Storage/Public/User/LCUser.cs
@@ -12,6 +12,7 @@ namespace LeanCloud.Storage {
     /// </summary>
     public class LCUser : LCObject {
         public const string CLASS_NAME = "_User";
+        public const string ENDPOINT = "users";
 
         private const string USER_DATA = ".userdata";
         private const string ANONYMOUS_DATA = ".anonymousdata";


### PR DESCRIPTION
## 背景

内置子类不再使用 `classes/_Xxx` 接口，统一改为 `xxxs` 接口。
[相关讨论](https://xindong.slack.com/archives/C01UL3RMUBX/p1695784016839889)

## 实现方案

调整注册子类方法，支持传入 `endpoint` 缺省参数，内置子类注册时传入对应 `xxxs`，自定义子类注册保持不变。

## 验证方法

单元测试通过，并且日志里没有出现 `/_` 相关的请求。