### PR TITLE
支持设置自定义请求超时时间

### DIFF
--- a/Common/Common/Http/LCHttpClient.cs
+++ b/Common/Common/Http/LCHttpClient.cs
@@ -42,7 +42,19 @@ namespace LeanCloud.Common {
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             client.DefaultRequestHeaders.Add("X-LC-Id", appId);
 
+            // 设置默认超时时间 10s
+            client.Timeout = TimeSpan.FromSeconds(10);
+
             md5 = MD5.Create();
+        }
+
+        public TimeSpan Timeout {
+            get {
+                return client.Timeout;
+            }
+            set {
+                client.Timeout = value;
+            }
         }
 
         public void AddRuntimeHeaderTask(string key, Func<Task<string>> task) {

--- a/Common/Common/Http/LCHttpClient.cs
+++ b/Common/Common/Http/LCHttpClient.cs
@@ -42,8 +42,8 @@ namespace LeanCloud.Common {
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             client.DefaultRequestHeaders.Add("X-LC-Id", appId);
 
-            // 设置默认超时时间 10s
-            client.Timeout = TimeSpan.FromSeconds(10);
+            // 设置默认超时时间 20s
+            client.Timeout = TimeSpan.FromSeconds(20);
 
             md5 = MD5.Create();
         }

--- a/Common/Common/LCCore.cs
+++ b/Common/Common/LCCore.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 
 namespace LeanCloud.Common {
     /// <summary>
@@ -37,6 +36,11 @@ namespace LeanCloud.Common {
 
         public static bool UseMasterKey {
             get; set;
+        }
+
+        public static TimeSpan RequestTimeout {
+            get => HttpClient.Timeout;
+            set { HttpClient.Timeout = value; }
         }
 
         public static PersistenceController PersistenceController {

--- a/Storage/Storage.Standard/Public/LCApplication.cs
+++ b/Storage/Storage.Standard/Public/LCApplication.cs
@@ -1,4 +1,5 @@
-﻿using LeanCloud.Common;
+﻿using System;
+using LeanCloud.Common;
 using LeanCloud.Storage.Internal;
 
 namespace LeanCloud {
@@ -7,6 +8,13 @@ namespace LeanCloud {
             get => LCCore.UseMasterKey;
             set {
                 LCCore.UseMasterKey = value;
+            }
+        }
+
+        public static TimeSpan RequestTimeout {
+            get => LCCore.RequestTimeout;
+            set {
+                LCCore.RequestTimeout = value;
             }
         }
 

--- a/Storage/Storage.Unity/Public/LCApplication.cs
+++ b/Storage/Storage.Unity/Public/LCApplication.cs
@@ -1,4 +1,5 @@
-﻿using LeanCloud.Common;
+﻿using System;
+using LeanCloud.Common;
 using LeanCloud.Storage.Internal;
 using LeanCloud.Storage.Internal.Persistence;
 
@@ -16,6 +17,13 @@ namespace LeanCloud {
             get => LCCore.UseMasterKey;
             set {
                 LCCore.UseMasterKey = value;
+            }
+        }
+
+        public static TimeSpan RequestTimeout {
+            get => LCCore.RequestTimeout;
+            set {
+                LCCore.RequestTimeout = value;
             }
         }
 


### PR DESCRIPTION
## 背景

SDK 之前使用默认请求超时时间 100s，有用户反馈太长了，体验不好。

## 调整

- 默认请求时间调整为 20s
- 支持通过 `LCApplication.RequestTimeout` 设置请求超时时间